### PR TITLE
fix: error when there's no REMOTE_ADDRESS from server

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -589,7 +589,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getPageIdentification()
     {
         $result = [
-            'ip' => $_SERVER ['REMOTE_ADDR'],
+            'ip' => $_SERVER['REMOTE_ADDR'] ?? $this->getQuote()->getRemoteIp(),
             'session' => $this->getSessionId(),
             'page_name' => $this->getPageName(),
             'url' => $this->getCurrentUrl()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "intelipost/magento2",
     "description": "Intelipost Shipping",
     "type": "magento2-module",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "require": {
         "guzzlehttp/guzzle": ">=6.3.3"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,7 +7,7 @@
  */
 -->
 <config>
-    <module name="Intelipost_Shipping" setup_version="2.7.0">
+    <module name="Intelipost_Shipping" setup_version="2.7.1">
         <sequence>
             <module name="Magento_Quote"/>
         </sequence>


### PR DESCRIPTION
There was an error when the server variable hasn't the REMOTE_ADDRESS value, it now uses a fallback IP from quote 