### PR TITLE
Fix: added possibility to select intelipost on tracking options

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -181,7 +181,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getPreDispatchEvents()
     {
-        return ['NEW', 'READY_FOR_SHIPPING', 'SHIPPED'];
+        return ['NEW', 'READY_FOR_SHIPPING'];
     }
 
     /**
@@ -189,7 +189,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getPostDispatchEvents()
     {
-        return ['TO_BE_DELIVERED', 'IN_TRANSIT', 'DELIVERED', 'CLARIFY_DELIVERY_FAIL', 'DELIVERY_FAILED'];
+        return ['SHIPPED', 'TO_BE_DELIVERED', 'IN_TRANSIT', 'DELIVERED', 'CLARIFY_DELIVERY_FAIL', 'DELIVERY_FAILED'];
     }
 
     /**

--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -464,9 +464,8 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
         return true;
     }
 
-    public function getTrackingInfo(string $trackingNumber): TrackingResult
+    public function getTrackingInfo(string $trackingNumber): array
     {
-        $result = $this->trackResultFactory->create();
-        return $result;
+        return ['number' => $trackingNumber];
     }
 }

--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -18,6 +18,8 @@ use Magento\Quote\Model\Quote\Address\RateResult\MethodFactory;
 use Magento\Shipping\Model\Carrier\AbstractCarrier;
 use Magento\Shipping\Model\Carrier\CarrierInterface;
 use Magento\Shipping\Model\Rate\ResultFactory;
+use Magento\Shipping\Model\Tracking\Result as TrackingResult;
+use Magento\Shipping\Model\Tracking\Result\Error as TrackingError;
 use Magento\Shipping\Model\Tracking\Result\ErrorFactory as TrackErrorFactory;
 use Magento\Shipping\Model\Tracking\Result\StatusFactory as TrackStatusFactory;
 use Magento\Shipping\Model\Tracking\ResultFactory as TrackResultFactory;
@@ -462,4 +464,9 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
         return true;
     }
 
+    public function getTrackingInfo(string $trackingNumber): TrackingResult
+    {
+        $result = $this->trackResultFactory->create();
+        return $result;
+    }
 }

--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -18,8 +18,6 @@ use Magento\Quote\Model\Quote\Address\RateResult\MethodFactory;
 use Magento\Shipping\Model\Carrier\AbstractCarrier;
 use Magento\Shipping\Model\Carrier\CarrierInterface;
 use Magento\Shipping\Model\Rate\ResultFactory;
-use Magento\Shipping\Model\Tracking\Result as TrackingResult;
-use Magento\Shipping\Model\Tracking\Result\Error as TrackingError;
 use Magento\Shipping\Model\Tracking\Result\ErrorFactory as TrackErrorFactory;
 use Magento\Shipping\Model\Tracking\Result\StatusFactory as TrackStatusFactory;
 use Magento\Shipping\Model\Tracking\ResultFactory as TrackResultFactory;
@@ -462,52 +460,6 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
     public function isTrackingAvailable()
     {
         return true;
-    }
-
-    /**
-     * Get tracking information
-     *
-     * @param string $tracking
-     * @return string|false
-     */
-    public function getTrackingInfo(string $trackingCode): TrackingResult
-    {
-        try {
-            $result = $this->trackResultFactory->create();
-
-            $tracking = $this->trackStatusFactory->create();
-            $tracking->setCarrier($this->getCarrierCode());
-            $tracking->setCarrierTitle($this->getConfigData('title'));
-            $tracking->setTracking($trackingCode);
-            $tracking->addData($this->proccessTrackDetails($trackingCode));
-
-            $result->append($tracking);
-
-        } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-            $error = $this->getTrackingError($trackingCode, 'There was an error request the tracking');
-            $result->append($error);
-        }
-
-        return $result;
-    }
-
-    protected function getTrackingError(string $trackingValue, string $errorMessage): TrackingError
-    {
-        $error = $this->trackErrorFactory->create();
-        $error->setCarrier($this->getCarrierCode());
-        $error->setCarrierTitle($this->getConfigData('title'));
-        $error->setTracking($trackingValue);
-        $error->setErrorMessage(__($errorMessage));
-        return $error;
-    }
-
-    protected function proccessTrackDetails(string $trackingCode): array
-    {
-        return [
-            'activity' => __('Tracking'),
-            'deliverylocation' => $trackingCode
-        ];
     }
 
 }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -70,12 +70,6 @@ class Popup
                 $trackingItem = $tracking[0];
                 if (is_array($trackingItem)) {
                     return $trackingItem['number'];
-                } else if ($trackingItem){
-
-                    $trackingDetails = $trackingItem->getAllTrackings();
-                    $trackingDetails = reset($trackingDetails);
-
-                    return $trackingDetails->getData('tracking');
                 }
             }
         }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -10,6 +10,7 @@ namespace Intelipost\Shipping\Plugin\Tracking;
 
 use Intelipost\Shipping\Helper\Data;
 use Magento\Shipping\Model\InfoFactory;
+use Magento\Shipping\Model\Tracking\Result;
 use Magento\Shipping\Model\Tracking\Result\AbstractResult;
 
 class Popup
@@ -61,17 +62,20 @@ class Popup
         $proceed();
     }
 
-    protected function getTrackingNumber($trackingInfo)
+    protected function getTrackingNumber(array $trackingInfo): string
     {
         $trackingNumber = '';
-        if (is_array($trackingInfo)) {
-            foreach ($trackingInfo as $tracking) {
-                if (isset($tracking[0])) {
-                    $this->helper->getLogger()->info(json_encode($tracking));
-                    $trackingItem = $tracking[0];
-                    if (is_array($trackingItem)) {
-                        return $trackingItem['number'];
-                    }
+        foreach ($trackingInfo as $tracking) {
+            if (isset($tracking[0])) {
+                $trackingItem = $tracking[0];
+                if (is_array($trackingItem)) {
+                    return $trackingItem['number'];
+                } else if ($trackingItem instanceof Result){
+
+                    $trackingDetails = $trackingItem->getAllTrackings();
+                    $trackingDetails = reset($trackingDetails);
+
+                    return $trackingItem->getData('tracking');
                 }
             }
         }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -67,11 +67,11 @@ class Popup
         if (is_array($trackingInfo)) {
             foreach ($trackingInfo as $tracking) {
                 if (isset($tracking[0])) {
+                    $this->helper->getLogger()->log(json_encode($tracking));
                     $trackingItem = $tracking[0];
                     if (is_array($trackingItem)) {
                         return $trackingItem['number'];
                     }
-                    $this->helper->getLogger()->error(json_encode($trackingItem));
                 }
             }
         }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -66,17 +66,12 @@ class Popup
         $trackingNumber = '';
         if (is_array($trackingInfo)) {
             foreach ($trackingInfo as $tracking) {
-                if (is_array($tracking)) {
-                    if (isset($tracking[0]['number'])) {
-                        $trackingNumber = $tracking['number'];
-                        break;
+                if (isset($tracking[0])) {
+                    $trackingItem = $tracking[0];
+                    if (is_array($trackingItem)) {
+                        return $trackingItem['number'];
                     }
-                } else {
-                    $this->helper->getLogger()->error(json_encode($tracking));
-//                    if ($tracking instanceof \Magento\Shipping\Model\Tracking\Result\Status) {
-//                        $trackingNumber = $tracking->getAllData();
-//                        break;
-//                    }
+                    $this->helper->getLogger()->error(json_encode($trackingItem));
                 }
             }
         }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -67,7 +67,7 @@ class Popup
         if (is_array($trackingInfo)) {
             foreach ($trackingInfo as $tracking) {
                 if (isset($tracking[0])) {
-                    $this->helper->getLogger()->log(json_encode($tracking));
+                    $this->helper->getLogger()->info(json_encode($tracking));
                     $trackingItem = $tracking[0];
                     if (is_array($trackingItem)) {
                         return $trackingItem['number'];

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -70,12 +70,12 @@ class Popup
                 $trackingItem = $tracking[0];
                 if (is_array($trackingItem)) {
                     return $trackingItem['number'];
-                } else if ($trackingItem instanceof Result){
+                } else if ($trackingItem){
 
                     $trackingDetails = $trackingItem->getAllTrackings();
                     $trackingDetails = reset($trackingDetails);
 
-                    return $trackingItem->getData('tracking');
+                    return $trackingDetails->getData('tracking');
                 }
             }
         }

--- a/Plugin/Tracking/Popup.php
+++ b/Plugin/Tracking/Popup.php
@@ -66,17 +66,17 @@ class Popup
         $trackingNumber = '';
         if (is_array($trackingInfo)) {
             foreach ($trackingInfo as $tracking) {
-                if (isset($tracking[0]['number'])) {
-                    $trackingNumber = $tracking[0]['number'];
-                    break;
-                }
-            }
-        } else if ($trackingInfo instanceof \Magento\Shipping\Model\Tracking\Result) {
-            $trackingInfo = $trackingInfo->getAllTrackings();
-            foreach ($trackingInfo as $tracking) {
                 if (is_array($tracking)) {
-                    $trackingNumber = $tracking['number'];
-                    break;
+                    if (isset($tracking[0]['number'])) {
+                        $trackingNumber = $tracking['number'];
+                        break;
+                    }
+                } else {
+                    $this->helper->getLogger()->error(json_encode($tracking));
+//                    if ($tracking instanceof \Magento\Shipping\Model\Tracking\Result\Status) {
+//                        $trackingNumber = $tracking->getAllData();
+//                        break;
+//                    }
                 }
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "intelipost/magento2",
     "description": "Intelipost Shipping",
     "type": "magento2-module",
-    "version": "2.7.4",
+    "version": "2.7.5",
     "require": {
         "guzzlehttp/guzzle": ">=6.3.3"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,7 +7,7 @@
  */
 -->
 <config>
-    <module name="Intelipost_Shipping" setup_version="2.7.4">
+    <module name="Intelipost_Shipping" setup_version="2.7.5">
         <sequence>
             <module name="Magento_Quote"/>
         </sequence>


### PR DESCRIPTION
**Title:**
Fix: added possibility to select intelipost on tracking options
TAG: v2.7.5

**Description:**
* It wasn't possible to add intelipost on tracking options when creating a new tracking

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable):

**Testing Instructions:**
* Create a new order, ship it and create a track, now it's possible to select "Intelipost"
