### PR TITLE
Feat: send source_code as warehouse code when it exists - v2.8.0

### DIFF
--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -290,7 +290,7 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
      * @param $postData
      * @return array
      */
-    public function getProductData($request, $postData)
+    public function getProductData($request, $postData): array
     {
         // Default Config
         $heightAttribute = $this->getConfigData('height_attribute');
@@ -395,7 +395,7 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
      * @param $qtdVolumes
      * @return array
      */
-    public function setProductsQuantity($qtdProducts, $qtdVolumes)
+    public function setProductsQuantity($qtdProducts, $qtdVolumes): array
     {
         $arrayVol = [];
         $result = (int) ($qtdProducts / $qtdVolumes);
@@ -416,10 +416,14 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
      * @return false|string|null
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getOriginZipcode($request)
+    public function getOriginZipcode($request): string
     {
         // Zipcodes
-        return $request->getOriginZipcode() ?: $this->getConfigData('source_zip');
+        $originPostCode = $request->getOriginZipcode() ?: (string) $this->getConfigData('source_zip');
+        if (!$originPostCode) {
+            $originPostCode = (string) $this->helper->getConfig('postcode', 'origin', 'shipping');
+        }
+        return $originPostCode;
     }
 
     /**
@@ -427,7 +431,7 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
      * @param $cartQty
      * @return array
      */
-    public function getVolumes($response, $cartQty)
+    public function getVolumes($response, $cartQty): array
     {
         $volumes = [];
         $volCount = count($response['content']['volumes']);

--- a/Model/ResourceModel/GetSourcesForOrder.php
+++ b/Model/ResourceModel/GetSourcesForOrder.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intelipost\Shipping\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Get allocated sources for specified order.
+ */
+class GetSourcesForOrder
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Get allocated sources by order ID
+     *
+     * @param int $orderId
+     * @return array
+     */
+    public function execute(int $orderId): array
+    {
+        $sources = [];
+        $shipmentsIds = $this->getShipmentIds($orderId);
+
+        /** Get sources for shipment ids */
+        if (!empty($shipmentsIds)) {
+            $connection = $this->resourceConnection->getConnection();
+            $sourceTableName = $this->resourceConnection->getTableName('inventory_source');
+            $shipmentSourceTableName = $this->resourceConnection->getTableName('inventory_shipment_source');
+
+            $select = $connection->select()
+                ->from(['inventory_source' => $sourceTableName])
+                ->joinInner(
+                    ['shipment_source' => $shipmentSourceTableName],
+                    'shipment_source.source_code = inventory_source.source_code',
+                    []
+                )
+                ->group('inventory_source.source_code')
+                ->where('shipment_source.shipment_id in (?)', $shipmentsIds);
+
+            $sources = $connection->fetchRow($select);
+        }
+
+        return $sources;
+    }
+
+    /**
+     * @param int $orderId
+     * @return mixed
+     */
+    public function getShipmentIds(int $orderId): mixed
+    {
+        $salesConnection = $this->resourceConnection->getConnection('sales');
+        $shipmentTableName = $this->resourceConnection->getTableName('sales_shipment', 'sales');
+        /** Get shipment ids for order */
+        $shipmentSelect = $salesConnection->select()
+            ->from(
+                ['sales_shipment' => $shipmentTableName],
+                ['shipment_id' => 'sales_shipment.entity_id']
+            )
+            ->where('sales_shipment.order_id = ?', $orderId);
+        return $salesConnection->fetchCol($shipmentSelect);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "intelipost/magento2",
     "description": "Intelipost Shipping",
     "type": "magento2-module",
-    "version": "2.7.5",
+    "version": "2.8.0",
     "require": {
         "guzzlehttp/guzzle": ">=6.3.3"
     },

--- a/etc/adminhtml/system/push.xml
+++ b/etc/adminhtml/system/push.xml
@@ -17,21 +17,30 @@
             <comment>If enabled it'll send order automatically to Intelipost</comment>
             <config_path>intelipost_push/order_status/enabled</config_path>
         </field>
+        <field id="order_by_shipment" translate="label comment" type="select" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="1">
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <label>Send items to Intelipost by Multi Shipment</label>
+            <config_path>intelipost_push/order_status/order_by_shipment</config_path>
+            <depends>
+                <field id="enabled">1</field>
+            </depends>
+        </field>
+        <field id="send_warehouse_code" translate="label comment" type="select" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <label>Send warehouse code to Intelipost</label>
+            <config_path>intelipost_push/order_status/send_warehouse_code</config_path>
+            <comment>When the order has the source attributed, it'll send it to Intelipost</comment>
+            <tooltip>The order must have shipment in order to allow the module get the source from the order</tooltip>
+            <depends>
+                <field id="enabled">1</field>
+            </depends>
+        </field>
         <field id="enable_cron" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <label>Send orders to Intelipost by cron</label>
             <config_path>intelipost_push/order_status/enable_cron</config_path>
             <depends>
                 <field id="enabled">1</field>
-            </depends>
-        </field>
-        <field id="order_by_shipment" translate="label comment" type="select" sortOrder="21" showInDefault="1" showInWebsite="1" showInStore="1">
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <label>Send items to Intelipost by Shipment</label>
-            <config_path>intelipost_push/order_status/order_by_shipment</config_path>
-            <depends>
-                <field id="enabled">1</field>
-                <field id="enable_cron">1</field>
             </depends>
         </field>
         <field id="cron_frequency" translate="label" type="select" sortOrder="22" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,7 +7,7 @@
  */
 -->
 <config>
-    <module name="Intelipost_Shipping" setup_version="2.7.5">
+    <module name="Intelipost_Shipping" setup_version="2.8.0">
         <sequence>
             <module name="Magento_Quote"/>
         </sequence>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -185,3 +185,7 @@ Description,Description
 "Number","Number"
 "Complement","Complement"
 "District","District"
+"Send items to Intelipost by Multi Shipment","Send items to Intelipost by Multi Shipment"
+"Send warehouse code to Intelipost","Send warehouse code to Intelipost"
+"When the order has the source attributed, it'll send it to Intelipost","When the order has the source attributed, it'll send it to Intelipost"
+"The order must have shipment in order to allow the module get the source from the order","The order must have shipment in order to allow the module get the source from the order"

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -187,3 +187,7 @@ Description,Descrição
 "District","Bairro"
 "Ship to Applicable Countries","Enviar para Países Aplicáveis"
 "Ship to Specific Countries","Enviar para Países Específicos"
+"Send items to Intelipost by Multi Shipment","Enviar itens para Intelipost por Multi Envio"
+"Send warehouse code to Intelipost","Enviar código do armazém para Intelipost"
+"When the order has the source attributed, it'll send it to Intelipost","Quando o pedido tiver o atributo de origem, irá enviar para a Intelipost"
+"The order must have shipment in order to allow the module get the source from the order","O pedido deve ter um envio para permitir que o módulo pegue a origem do pedido"


### PR DESCRIPTION
**Title:**
Send source_code ad warehouse code when it exists


**Description:**
When an order had a source attached to it, the module can send this source code as a warehouse code


![Order List with Source attached to it](https://github.com/user-attachments/assets/f1447395-e1e5-4a47-a18d-f0fa671f11ca)
![settings](https://github.com/user-attachments/assets/24b9d283-067a-4d22-9b48-e9fbe7174233)


**Checklist:**
- [x] Changes are consistent with the project's coding style.

**Testing Instructions:**
a) Enable the config to send source code to Intelipost.
b) Create a new order and set a shipment to attach a source to it.
c) Send this order to Intelipost, the attribute origin_warehouse_code will be sent with source code on it.
