### PR TITLE
Fix incorrect delivery time estimates in Intelipost Shipping Module

### DIFF
--- a/Model/Carrier/Intelipost.php
+++ b/Model/Carrier/Intelipost.php
@@ -243,24 +243,19 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
             $deliveryEstimateDateExactISO = $child['delivery_estimate_date_exact_iso'] ?? null;
 
             if ($deliveryEstimateDateExactISO) {
-                $child['delivery_estimate_business_days'] = date('d/m/Y', strtotime($deliveryEstimateDateExactISO));
                 $method->setDeliveryEstimateDateExactIso($deliveryEstimateDateExactISO);
             }
-
-            $child['delivery_estimate_business_days'] = ($deliveryEstimateDateExactISO)
-                ? $child['delivery_estimate_business_days']
-                : $deliveryEstimateBusinessDays;
 
             $methodTitle = $this->helper->getCustomCarrierTitle(
                 $this->_code,
                 $child['description'],
-                $child['delivery_estimate_business_days'],
+                $deliveryEstimateBusinessDays,
                 $schedulingEnabled
             );
             $methodDescription = $this->helper->getCustomCarrierTitle(
                 $this->_code,
                 $child['delivery_method_name'],
-                $child['delivery_estimate_business_days'],
+                $deliveryEstimateBusinessDays,
                 $schedulingEnabled
             );
 
@@ -268,7 +263,6 @@ class Intelipost extends AbstractCarrier implements CarrierInterface
             $method->setMethodDescription($methodDescription);
             $method->setDeliveryMethodType($child['delivery_method_type']);
 
-            $child['delivery_estimate_business_days'] = $deliveryEstimateBusinessDays;
             $amount = $child['final_shipping_cost'];
             $cost = $child['provider_shipping_cost'];
 


### PR DESCRIPTION
## Description:
* This PR fixes a critical bug in the Intelipost shipping module where delivery time estimates are displayed incorrectly to customers.
* The issue occurs because the module incorrectly overwrites the numeric business days value with a formatted date string, then later casts this string to an integer, resulting in wrong day values.

**Problem Identified:**
The code in `Intelipost.php` has multiple redundant assignments of `$child['delivery_estimate_business_days']`:

1. Line 246 corrupts the business days value by overwriting it with a date string:
   ```php
   $child['delivery_estimate_business_days'] = date('d/m/Y', strtotime($deliveryEstimateDateExactISO));
   ```

2. Lines 250-252 contain a redundant ternary operation that doesn't fix the problem:
   ```php
   $child['delivery_estimate_business_days'] = ($deliveryEstimateDateExactISO)
       ? $child['delivery_estimate_business_days']
       : $deliveryEstimateBusinessDays;
   ```

3. Line 271 tries to restore the original value, but it's too late (after title generation):
   ```php
   $child['delivery_estimate_business_days'] = $deliveryEstimateBusinessDays;
   ```

**Changes Made:**
1. Removed line 246 that was corrupting the business days value with date string conversion
2. Modified title generation to use the stored `$deliveryEstimateBusinessDays` variable instead of `$child['delivery_estimate_business_days']`
3. Removed the unnecessary assignment at line 271

This fix ensures that the original numeric business days value from the API is preserved and used correctly in the title generation process.

## Checklist:
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (if applicable) has been updated.
- [x] Link to related issue (if applicable): #37 

## Testing Instructions:
1. Configure Intelipost shipping module in Magento
2. Add a product to cart and proceed to checkout
3. Enter a destination ZIP code to calculate shipping rates
4. Verify that the delivery time estimates display the correct business days:

**Before fix:**
```
"title": "Carrier title - 26 Dias úteis para entrega"
```

**After fix:**
```
"title": "Carrier title - 8 Dias úteis para entrega"
```
