### PR TITLE
fix: resolve deprecated nullable parameter typing for PHP 8.4 compatibility

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -369,7 +369,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * @param array|null $data
      */
-    public function saveResultQuotes(array $data = null)
+    public function saveResultQuotes(?array $data = null)
     {
         $this->customerSession->setData(self::RESULT_QUOTES, $data);
     }
@@ -539,7 +539,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @return array|null
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getAdditionalInformation(array $additional = null)
+    public function getAdditionalInformation(?array $additional = null)
     {
         $result = [
             'client_type' => $this->getCustomerGroup(),

--- a/Model/Config/CronConfig.php
+++ b/Model/Config/CronConfig.php
@@ -50,8 +50,8 @@ class CronConfig extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\App\Config\ValueFactory $configValueFactory,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection = null,
         $runModelPath = '',
         array $data = []
     ) {

--- a/Model/ResourceModel/Shipment/Collection.php
+++ b/Model/ResourceModel/Shipment/Collection.php
@@ -43,8 +43,8 @@ class Collection extends AbstractCollection
         FetchStrategyInterface $fetchStrategy,
         ManagerInterface $eventManager,
         StoreManagerInterface $storeManager,
-        AdapterInterface $connection = null,
-        AbstractDb $resource = null
+        AdapterInterface|null $connection = null,
+        AbstractDb|null $resource = null
     )
     {
         $this->_init(


### PR DESCRIPTION
This pull request makes minor improvements to type hinting in the `Helper/Data.php` file by updating method signatures to use nullable array syntax. This change increases code clarity and aligns with modern PHP standards.

- **Type Hinting Improvements:**
  * Updated the `saveResultQuotes` and `getAdditionalInformation` methods to use the nullable array type hint (`?array`) instead of accepting `array|null`. [[1]](diffhunk://#diff-d52e7365b52ebb360796c9734ab3a62d2bd9f6097e38c253892c3d22a36668b5L372-R372) [[2]](diffhunk://#diff-d52e7365b52ebb360796c9734ab3a62d2bd9f6097e38c253892c3d22a36668b5L542-R542)**Title:**

**Description:**
* In PHP 8.4, parameters typed as non-nullable (e.g. array) can no longer implicitly use = null, requiring the type to be explicitly declared as nullable (?array or array|null).

**Checklist:**
- [X] Changes are consistent with the project's coding style.
- [X] Documentation (if applicable) has been updated.
- [X] Link to related issue (if applicable):

**Testing Instructions:**
* The module should continue working as-is after the fix, with the only change being the explicit declaration of nullable parameter types to ensure compatibility with PHP 8.4 and remove deprecation warnings.

PHPDOC: [https://www.php.net/manual/en/migration84.deprecated.php?utm_source=chatgpt.com](https://www.php.net/manual/en/migration84.deprecated.php?utm_source=chatgpt.com)

fix: #43 
