### PR TITLE
fix: API Error while saving invoice protocol and invoice type (TMS-3082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.1] - 2026-07-01
+### Fixed
+- API Error while saving invoice protocol and invoice type
+
+---
 ## [2.11.0] - 2025-11-25
 ### Added
 - Added Pick-up options to shipping methods

--- a/Model/ResourceModel/InvoiceRepository.php
+++ b/Model/ResourceModel/InvoiceRepository.php
@@ -105,6 +105,8 @@ class InvoiceRepository implements InvoiceRepositoryInterface
             $invoice->setTotalValue($nfe->getTotalValue());
             $invoice->setProductsValue($nfe->getProductsValue());
             $invoice->setCfop($nfe->getCfop());
+            $invoice->setInvoiceProtocol($nfe->getInvoiceProtocol());
+            $invoice->setInvoiceType($nfe->getInvoiceType());
 
             $this->resource->save($invoice);
         }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "intelipost/magento2",
     "description": "Intelipost Shipping",
     "type": "magento2-module",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "require": {
         "guzzlehttp/guzzle": ">=6.3.3"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,7 +7,7 @@
  */
 -->
 <config>
-    <module name="Intelipost_Shipping" setup_version="2.11.0">
+    <module name="Intelipost_Shipping" setup_version="2.11.1">
         <sequence>
             <module name="Magento_Quote"/>
         </sequence>


### PR DESCRIPTION
**Description:**
* `Model/ResourceModel/InvoiceRepository::saveInvoices()` never copied `invoice_protocol` (`nProt`) and `invoice_type` (`tpNF`) from the parsed NFe onto the `Invoice` entity before saving.
* Both columns are declared `nullable="false"` in `etc/db_schema.xml`, so the persist failed with **"API Error while saving invoice protocol and invoice type"**.
* Fix adds the two missing setters (mirrors the existing setter list). Getters/setters and the parser (`NfeXmlParser`) already populate these values.
* Module bumped `2.11.0 -> 2.11.1` (`composer.json`, `etc/module.xml`, `CHANGELOG.md`).
* Scope is limited to the invoice save path — no impact on the recent Correios changes.

This replaces external fork PR #50 (`contardi/master -> master`) with an internal-branch PR following the repo pattern.

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [x] Documentation (CHANGELOG) has been updated.
- [x] Link to related issue (if applicable): TMS-3082

**Testing Instructions:**
* Import/generate an order whose NFe XML carries `nProt` (protocol) and `tpNF` (type).
* Trigger the invoice save flow and confirm it completes with no "API Error while saving invoice protocol and invoice type".
* Verify the `intelipost_shipping_invoice` row has `invoice_protocol` and `invoice_type` populated (visible in the admin invoices listing).
